### PR TITLE
Change from GCR to GHCR to host public images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tomthorogood
+* @UWIT-IAM/iam-peer-reviewers

--- a/.github/update-image.sh
+++ b/.github/update-image.sh
@@ -3,8 +3,8 @@
 set -e  # Exit on any error
 BUILD_OPTIONS=
 EDGE_TAG=${EDGE_TAG:-'latest'}
-GCR_PROJECT=${GCR_PROJECT:-uwit-mci-iam}
-GCR_HOST=${GCR_HOST:-gcr.io}
+DOCKER_HOST=${DOCKER_HOST:-ghcr.io}
+REPO_OWNER=uwit-iam
 
 while (( $# ))
 do
@@ -25,10 +25,6 @@ do
       ;;
     --no-pull) # Skip pulling the image; good for bootstrapping.
       NO_PULL=1
-      ;;
-    --gcr-key-file|-key)
-      shift
-      GOOGLE_APPLICATION_CREDENTIALS=$1
       ;;
     --target|-t)  # Optional; provide a target inside a dockerfile
       shift
@@ -88,8 +84,8 @@ function push-image() {
 }
 
 
-CANONICAL_IMAGE=${GCR_HOST}/${GCR_PROJECT}/${REPO}:${VERSION}
-EDGE_IMAGE=${GCR_HOST}/${GCR_PROJECT}/${REPO}:${EDGE_TAG}
+CANONICAL_IMAGE=${DOCKER_HOST}/${REPO_OWNER}/${REPO}:${VERSION}
+EDGE_IMAGE=${DOCKER_HOST}/${REPO_OWNER}/${REPO}:${EDGE_TAG}
 
 if [[ -z ${NO_PULL} ]]
 then

--- a/.github/workflows/validate-build-push.yml
+++ b/.github/workflows/validate-build-push.yml
@@ -5,9 +5,7 @@ on:
     - cron: '0 2 * * 1'  # Run at 2am every Monday.
 
 env:
-  GCR_PROJECT: uwit-mci-iam
   EDGE_TAG: latest
-  GCR_HOST: gcr.io
   DRY_RUN: ${{  github.event != 'schedule' }}
 
 jobs:
@@ -18,15 +16,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Set VERSION"
         run: echo "VERSION=$(date +%Y.%-j.%-I.%-M)" >> $GITHUB_ENV
-      - name: Docker login with GCP credentials
-        id: gcp-login
-        shell: bash
-        env:
-          GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
-        run: |
-          echo "${GCR_TOKEN}" |
-          base64 -d |
-          docker login --username=_json_key --password-stdin https://${GCR_HOST}
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: update-image
         run: ./.github/update-image.sh -r poetry
       - name: Update uw-saml-poetry image

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UW-IT IAM Docker Library
 
 This repository contains the dockerfiles of some shared images that are available 
-on [gcr.io] for the UW-IT IAM team.
+on [ghcr.io] for anyone to consume.
 
 Github will run scheduled actions to rebuild these images and keep them up to date. 
 These scheduled builds are always tagged with their build as a pseudo-semver as:
@@ -29,7 +29,7 @@ good idea to set up your own scheduled actions to keep stagnant dependents up to
     build your package inside the container.
 - [uw-saml-poetry](images/uw-saml-poetry.dockerfile)
   - Installs [uw-saml-python] and its dependencies, which is a heavy lift on its own.
-    This descends from uwitiam/poetry above. 
+    This descends from poetry above. 
    
 
 # Contributing
@@ -37,8 +37,9 @@ good idea to set up your own scheduled actions to keep stagnant dependents up to
 Contributions to our ecosystem are welcome! If you would like to add images here to 
 be reused, feel free. Some things to keep in mind:
 
-- The images should not require any special credentials or permissions, save for access to [gcr.io]. Anyone on our team should be able to use them.
+- The images should not require any special credentials to pull; public means public.
+  **Do not build any secret values into the images!**
 
 
-[gcr.io]: https://gcr.io/uwit-mci-iam
+[ghcr.io]: https://github.com/orgs/UWIT-IAM/packages
 [uw-saml-python]: https://github.com/uwit-iam/uw-saml-python

--- a/images/uw-saml-poetry.dockerfile
+++ b/images/uw-saml-poetry.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/uwit-mci-iam/poetry:latest as uwit-iam-xmlsec-base
+FROM ghcr.io/uwit-iam/poetry:latest as uwit-iam-xmlsec-base
 WORKDIR $POETRY_HOME
 COPY images/uw-saml-poetry/* ./
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"


### PR DESCRIPTION
This change does not affect any existing production software.

This will make it much easier to consume these shared images during our Actions and other build processes. Since these were always intended to be public,  I am simply fulfilling my own feature request to make it possible at an org level. 

This will have no impact on packages still consuming the gcr versions of these (which is only the husky directory at the moment), however those versions will no longer be updated via regular maintenance. 

