### PR TITLE
Remove no-longer-necessary `PATH` override (depends on #4)

### DIFF
--- a/images/uw-saml-poetry.dockerfile
+++ b/images/uw-saml-poetry.dockerfile
@@ -1,5 +1,4 @@
 FROM ghcr.io/uwit-iam/poetry:latest as uwit-iam-xmlsec-base
 WORKDIR $POETRY_HOME
 COPY images/uw-saml-poetry/* ./
-ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
 RUN ./bootstrap-xmlsec-env.sh


### PR DESCRIPTION
Depends on #4 

Once the change to the `poetry` image is released, the PATH override will no longer be needed for the `uw-saml-poetry` image.