### PR TITLE
Fix workflow DRY_RUN argument

### DIFF
--- a/.github/workflows/validate-build-push.yml
+++ b/.github/workflows/validate-build-push.yml
@@ -6,7 +6,9 @@ on:
 
 env:
   EDGE_TAG: latest
-  DRY_RUN: ${{  github.event != 'schedule' }}
+  # We dry run on every code push except those to main.
+  # In all other events, we publish the new version.
+  DRY_RUN: ${{  github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 jobs:
   update-images:


### PR DESCRIPTION
Apparently this has only been doing dry runs every week 😢 

`github.event` was never `"schedule"`, because it should have been `github.event_name` instead.

This fixes the problem, and also ensures that merges to main update the `latest` as well.