### PR TITLE
added centos7 base image definition.

### DIFF
--- a/images/centos7/Dockerfile
+++ b/images/centos7/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:centos7
+
+LABEL org.opencontainers.image.vendor="UW-IT" \
+      org.opencontainers.image.authors="Justin Prosser"
+
+# dump out container image details for the logs
+RUN echo "hello centos (amd64, arm64, ppc64)"
+RUN echo -n "current OS is: "; uname -p
+
+# Pull latest CentOS 7 updates
+RUN yum update -y
+RUN yum erase -y linux-firmware
+RUN yum clean all
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+
+CMD uname -a && sleep infinity

--- a/images/centos7/README.md
+++ b/images/centos7/README.md
@@ -1,0 +1,3 @@
+# Cent OS 7 base image
+
+This the IAM CentOS 7 base image providing a weekly(?) updated base to build containers from.


### PR DESCRIPTION
Simple base image definition for CentOS 7 motivated by Docker Hub's [depreciation notice](https://hub.docker.com/_/centos) and last updated image now years old.