### PR TITLE
Build multiplatform images

### DIFF
--- a/.github/workflows/update-base-python-images.yaml
+++ b/.github/workflows/update-base-python-images.yaml
@@ -1,9 +1,6 @@
 name: "Update base Python container images"
 
 on:
-  push:
-    branches:
-      - 'main'
   schedule:
     - cron: '0 0 * * MON'
   workflow_dispatch:
@@ -32,21 +29,30 @@ jobs:
         uses: 'uwit-iam/action-auth-artifact-registry@main'
         with:
           credentials: "${{ secrets.MCI_GCLOUD_AUTH_JSON }}"
+          enable_private_docker: true
 
       - name: Record timestamp for image
         id: timestamp
         run: |
           echo "value=$(date +%Y.%m.%d.%H.%M.%S)" >> $GITHUB_OUTPUT  # e.g., 2024.01.17.15.09.31
 
-      - name: Build and push docker image
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push to GAR
         env:
           image_uri: "us-docker.pkg.dev/uwit-mci-iam/containers/base-python-${{ matrix.py_version }}"
-        run: |
-          docker build \
-            images/python-base/ \
-            -f images/python-base/Dockerfile \
-            -t "${{ env.image_uri }}:latest" \
-            -t "${{ env.image_uri }}:${{ steps.timestamp.outputs.value }}" \
-            --build-arg TIMESTAMP="${{ steps.timestamp.outputs.value }}" \
-            --build-arg PYTHON_VERSION="${{ matrix.py_version }}"
-          docker push --all-tags "${{ env.image_uri }}"
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:images/python-base"
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PYTHON_VERSION=${{ matrix.py_version }}
+            TIMESTAMP=${{ steps.timestamp.outputs.value }}
+          push: true
+          tags: |
+            ${{ env.image_uri }}:latest
+            ${{ env.image_uri }}:${{ steps.timestamp.outputs.value }}


### PR DESCRIPTION
This PR adds support for multi-platform builds. It follows the example in Docker's GH Action to build and push two Python images: one for x86 platforms and one for arm64 (aka M1 Macs): https://github.com/docker/build-push-action?tab=readme-ov-file#usage

This was developed and tested successfully at https://github.com/UWIT-IAM/docker-library/actions/workflows/multi-arch-test.yaml

Here is a link to the manifest/images that were uploaded to GAR as a part of that test: https://console.cloud.google.com/artifacts/docker/uwit-mci-iam/us/containers/base-python-3.9kevintest/sha256:cf2d67208c8d3867d75de28b0f786857361475afdad6f8d54cf6ef738eb841a7;tab=manifest?project=uwit-mci-iam

I also tested locally to check that Docker automatically fetches the appropriate platform-specific image, and it does.

### Other Changes

- Removed `push` workflow trigger. I'm open to restoring this if you think it's needed, but I feel like allowing it simply execute on the existing cron schedule is sufficient.



