### PR TITLE
Updated the URL for the Python releases.

### DIFF
--- a/.github/workflows/update-base-python-images.yaml
+++ b/.github/workflows/update-base-python-images.yaml
@@ -15,7 +15,7 @@ jobs:
     - id: set-pythons
       run: |
         ## script to get current Python versions from the source of truth
-        data=`curl -s --url "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"`
+        data=`curl -s --url "https://peps.python.org/api/release-cycle.json"`
         pythonarray=`echo ${data} | jq '.[] | select((.status!="end-of-life") and (.status!="prerelease")) | select(.branch | startswith("3.")) | .branch' | jq -s -c`
         echo "pythons=${pythonarray}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This is from here: [python devguide](https://github.com/python/devguide/blob/f657b399c31fef3682249e65835772bee1ae2a4b/conf.py#L186)